### PR TITLE
Enhance API to also work with self hosted ct installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ To login with username and password, use this code snippet:
 $api = \ChurchTools\Api\RestApi::createWithUsernamePassword('mychurch', 'username', 'password');
 ```
 where `mychurch` is your church handle or subdomain like in the URL to your web interface: https://_churchhandle_.church.tools/
+if you are selfhsoting churchtools, then put ni the full server name of your installation.
 
 To login with a login ID and token, use this code snippet (recommended):
 ```

--- a/src/ChurchTools/Api/RestApi.php
+++ b/src/ChurchTools/Api/RestApi.php
@@ -97,7 +97,7 @@ class RestApi
      *
      * @param array $categoryIds the calendar ids for which to get the events
      * @param int $fromDays starting time frame in days from today
-     * @param int $toDays end of time frame in days from tdoay
+     * @param int $toDays end of time frame in days from today
      * @return array
      * @see https://api.churchtools.de/class-CTChurchCalModule.html#_getCalendarEvents
      */

--- a/src/ChurchTools/Api/RestApi.php
+++ b/src/ChurchTools/Api/RestApi.php
@@ -12,7 +12,8 @@ use ChurchTools\Api\Exception\RestApiException;
  */
 class RestApi
 {
-    const API_URL_TEMPLATE = 'https://%s.church.tools/?q=%s';
+    const API_URL_TEMPLATE = 'https://%s/?q=%s'; // Self hosted
+    const API_URL_TEMPLATE_HOSTED = 'https://%s.church.tools/?q=%s'; // Hosted by CT
     const LOGIN_ROUTE = 'login/ajax';
     const DATABASE_ROUTE = 'churchdb/ajax';
     const CALENDAR_ROUTE = 'churchcal/ajax';
@@ -207,6 +208,13 @@ class RestApi
      */
     private function getApiUrl(string $route): string
     {
-        return sprintf(self::API_URL_TEMPLATE, $this->churchHandle, $route);
+        if (strpos($this->churchHandle, '.'))
+        {
+            return sprintf(self::API_URL_TEMPLATE, $this->churchHandle, $route);
+        }
+        else
+        {
+            return sprintf(self::API_URL_TEMPLATE_HOSTED, $this->churchHandle, $route);
+        }
     }
 }


### PR DESCRIPTION
Solve issue #2 
To retain the existing api, we just check if at least one dot is found in the $churchHandle argument.
In that case it must be a full hostname, since ct hsoting does not support subdomains like site1.mychurch.church.tools