### PR TITLE
Don't filter calendar entries which start before start date

### DIFF
--- a/src/ChurchTools/Api/Tools/CalendarTools.php
+++ b/src/ChurchTools/Api/Tools/CalendarTools.php
@@ -25,8 +25,9 @@ class CalendarTools
     {
         $retVal = array_filter($calendarEntries,
             function($entry) use ($startDate, $endDate) {
-            return $entry->getStartDate()->getTimestamp() >= $startDate && $entry->getStartDate()->getTimestamp()
-                <= $endDate;
+            return $entry->getStartDate()->getTimestamp() <= $endDate && 
+                ($entry->getStartDate()->getTimestamp() >= $startDate ||
+                ($entry->getEndDate()->getTimestamp() >= $startDate)) ;
         });
         return $retVal;
     }


### PR DESCRIPTION
Don't filter calendar entries which start before start date in/after end date

Can you please commit this request and make a new release ?

0.4.1 would be enough, since it's a very small fix and no new features